### PR TITLE
Update deprecated actions/{upload|download}-artifact@v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           python setup.py sdist --formats=zip
       - name: ⬆ Upload build result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
@@ -40,7 +40,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: ⬇ Download build result
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
@@ -60,7 +60,7 @@ jobs:
       - test-install
     steps:
       - name: ⬇ Download build result
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist


### PR DESCRIPTION
The v3 artifact actions will cease functioning on Jan 30th, see https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/